### PR TITLE
feature/login-hypothesis-notification

### DIFF
--- a/features/ati/AtiManuscript/index.tsx
+++ b/features/ati/AtiManuscript/index.tsx
@@ -18,6 +18,7 @@ import DeleteManuscriptModal from "./DeleteManuscriptModal"
 import IngestPdf from "./IngestPdf"
 import UploadManuscriptModal from "./UploadManuscriptModal"
 import { uploadManuscriptReducer } from "./UploadManuscriptModal/state"
+import HypothesisLoginNotification from "../../auth/HypothesisLoginNotificaton"
 import useBoolean from "../../../hooks/useBoolean"
 
 import { ManuscriptMimeType, ManuscriptFileExtension } from "../../../constants/arcore"
@@ -219,6 +220,7 @@ const AtiManuscript: FC<AtiManuscriptProps> = ({
         handleUploadManuscript={handleUploadManuscript}
       />
       <div className={styles.tabContainer}>
+        <HypothesisLoginNotification />
         <div className={styles.buttonContainer}>
           <Button
             className={styles.blackButton}

--- a/features/auth/HypothesisLoginNotificaton/HypothesisLoginNotification.stories.tsx
+++ b/features/auth/HypothesisLoginNotificaton/HypothesisLoginNotification.stories.tsx
@@ -1,0 +1,12 @@
+import { Story, Meta } from "@storybook/react"
+
+import HypothesisLoginNotification from "."
+
+export default {
+  component: HypothesisLoginNotification,
+  title: "Auth/Hypothesis Login Notification",
+} as Meta
+
+const Template: Story = (args) => <HypothesisLoginNotification {...args} />
+
+export const Default = Template.bind({})

--- a/features/auth/HypothesisLoginNotificaton/index.tsx
+++ b/features/auth/HypothesisLoginNotificaton/index.tsx
@@ -9,7 +9,7 @@ const HypothesisLoginNotification: FC = () => {
       lowContrast
       kind="info"
       statusIconDescription="info"
-      title="Use the Annotation sidebar to log in to Hypothes.is and see your annotations"
+      title="Log in to Hypothes.is to see your annotations in the Annotation sidebar."
       actions={<NotificationActionButton>OK</NotificationActionButton>}
     />
   )

--- a/features/auth/HypothesisLoginNotificaton/index.tsx
+++ b/features/auth/HypothesisLoginNotificaton/index.tsx
@@ -1,18 +1,38 @@
-import { FC } from "react"
+import { FC, useState, useEffect } from "react"
 
 import { InlineNotification, NotificationActionButton } from "carbon-components-react"
 
+const HYPOTHESIS_LOGIN_NOTIFICATION_IS_VISIBLE = "hypotheis-login-notification-is-visible"
+
 const HypothesisLoginNotification: FC = () => {
-  return (
-    <InlineNotification
-      hideCloseButton
-      lowContrast
-      kind="info"
-      statusIconDescription="info"
-      title="Log in to Hypothes.is to see your annotations in the Annotation sidebar."
-      actions={<NotificationActionButton>OK</NotificationActionButton>}
-    />
-  )
+  const [notificationIsVisible, setNotificationIsVisible] = useState(false)
+
+  const onClickOK = () => {
+    localStorage.setItem(HYPOTHESIS_LOGIN_NOTIFICATION_IS_VISIBLE, "false")
+    setNotificationIsVisible(false)
+  }
+
+  useEffect(() => {
+    const isVisible = localStorage.getItem(HYPOTHESIS_LOGIN_NOTIFICATION_IS_VISIBLE)
+    if (isVisible === null || isVisible === "true") {
+      setNotificationIsVisible(true)
+    }
+  }, [])
+
+  if (notificationIsVisible) {
+    return (
+      <InlineNotification
+        hideCloseButton
+        lowContrast
+        kind="info"
+        statusIconDescription="info"
+        title="Log in to Hypothes.is to see your annotations in the Annotation sidebar."
+        actions={<NotificationActionButton onClick={onClickOK}>OK</NotificationActionButton>}
+      />
+    )
+  }
+
+  return null
 }
 
 export default HypothesisLoginNotification

--- a/features/auth/HypothesisLoginNotificaton/index.tsx
+++ b/features/auth/HypothesisLoginNotificaton/index.tsx
@@ -1,0 +1,18 @@
+import { FC } from "react"
+
+import { InlineNotification, NotificationActionButton } from "carbon-components-react"
+
+const HypothesisLoginNotification: FC = () => {
+  return (
+    <InlineNotification
+      hideCloseButton
+      lowContrast
+      kind="info"
+      statusIconDescription="info"
+      title="Use the Annotation sidebar to log in to Hypothes.is and see your annotations"
+      actions={<NotificationActionButton>OK</NotificationActionButton>}
+    />
+  )
+}
+
+export default HypothesisLoginNotification


### PR DESCRIPTION
Resolves #21 

In addition to initially showing the Annotation sidebar, display an inline notification to warn users that that they need to login to hypothes.is to see their annotations in the Annotation sidebar.

Once the user has "confirm" this message, the user's confirmation is saved to local storage so that they don't have to see the notification again.