### PR TITLE
feature/add-hypothesis-groupquery-parameter-to-download-annotations-endpoint

### DIFF
--- a/constants/hypothesis.ts
+++ b/constants/hypothesis.ts
@@ -1,0 +1,1 @@
+export const HYPOTHESIS_PUBLIC_GROUP_ID = "__world__"

--- a/features/ati/AtiExportAnnotations/index.tsx
+++ b/features/ati/AtiExportAnnotations/index.tsx
@@ -14,6 +14,7 @@ import {
   Toggle,
 } from "carbon-components-react"
 
+import { HYPOTHESIS_PUBLIC_GROUP_ID } from "../../../constants/hypothesis"
 import { IManuscript } from "../../../types/dataverse"
 import { IHypothesisGroup } from "../../../types/hypothesis"
 import { getMessageFromError } from "../../../utils/httpRequestUtils"
@@ -43,6 +44,9 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
     let didCancel = false
     const getAnnotationsJson = async () => {
       const { data } = await axios.get(`/api/hypothesis/${datasetId}/download-annotations`, {
+        params: {
+          hypothesisGroup: HYPOTHESIS_PUBLIC_GROUP_ID,
+        },
         headers: {
           Accept: "application/json",
         },
@@ -73,7 +77,9 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
     setTaskStatus("active")
     setTaskDesc("Downloading annotations...")
     await axios
-      .get(`/api/hypothesis/${datasetId}/download-annotations`)
+      .get(`/api/hypothesis/${datasetId}/download-annotations`, {
+        params: { hypothesisGroup: HYPOTHESIS_PUBLIC_GROUP_ID },
+      })
       .then(({ data }) => {
         setTaskDesc("Exporting annotations...")
         return axios.post(

--- a/features/ati/AtiManuscript/index.tsx
+++ b/features/ati/AtiManuscript/index.tsx
@@ -22,6 +22,7 @@ import HypothesisLoginNotification from "../../auth/HypothesisLoginNotificaton"
 import useBoolean from "../../../hooks/useBoolean"
 
 import { ManuscriptMimeType, ManuscriptFileExtension } from "../../../constants/arcore"
+import { HYPOTHESIS_PUBLIC_GROUP_ID } from "../../../constants/hypothesis"
 import { IDatasource, IManuscript } from "../../../types/dataverse"
 import { getMimeType } from "../../../utils/fileUtils"
 import { getMessageFromError } from "../../../utils/httpRequestUtils"
@@ -148,6 +149,9 @@ const AtiManuscript: FC<AtiManuscriptProps> = ({
             ? axios({
                 method: "GET",
                 url: `/api/hypothesis/${datasetId}/download-annotations`,
+                params: {
+                  hypothesisGroup: HYPOTHESIS_PUBLIC_GROUP_ID,
+                },
               }).then(({ data }) => {
                 if (data.total > 0) {
                   setTaskDesc(

--- a/features/ati/AtiSettings/index.tsx
+++ b/features/ati/AtiSettings/index.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/router"
 
 import DeleteAtiModal from "./DeleteAtiModal"
 
+import { HYPOTHESIS_PUBLIC_GROUP_ID } from "../../../constants/hypothesis"
 import useBoolean from "../../../hooks/useBoolean"
 import { IDataset, IManuscript } from "../../../types/dataverse"
 import { getMessageFromError } from "../../../utils/httpRequestUtils"
@@ -49,7 +50,9 @@ const AtiSettings: FC<AtiSettingsProps> = ({ dataset, manuscript }) => {
         }
       })
       .then(() => {
-        return axios.get(`/api/hypothesis/${dataset.id}/download-annotations`)
+        return axios.get(`/api/hypothesis/${dataset.id}/download-annotations`, {
+          params: { hypothesisGroup: HYPOTHESIS_PUBLIC_GROUP_ID },
+        })
       })
       .then(({ data }) => {
         if (data.total > 0) {

--- a/pages/api/hypothesis/[id]/download-annotations.ts
+++ b/pages/api/hypothesis/[id]/download-annotations.ts
@@ -13,7 +13,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (req.method === "GET") {
     const session = await getSession({ req })
     if (session) {
-      const { id } = req.query
+      const { id, hypothesisGroup } = req.query
       const uri = `${process.env.NEXTAUTH_URL}/ati/${id}/${AtiTab.manuscript.id}`
       const searchEndpoint = `${process.env.HYPOTHESIS_SERVER_URL}/api/search`
       const { hypothesisApiToken } = session
@@ -23,6 +23,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         .get(searchEndpoint, {
           params: {
             limit: 1,
+            group: hypothesisGroup,
             uri,
           },
           headers: {
@@ -39,6 +40,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
               return axios.get(searchEndpoint, {
                 params: {
                   limit: ANNOTATIONS_MAX_LIMIT,
+                  group: hypothesisGroup,
                   uri,
                   offset,
                 },


### PR DESCRIPTION
- Caller of the `/api/download-annotations` endpoint can specify which hypothesis group the annotations should be downloaded from.
- Modify all current calls to `/api/download-annotations` to use the `__world__` hypothesis group
- To implement #24 , as a part of the review process, when the admin deletes annotations, the app will download annotations from the ATI staging group and deletes them.


