### PR TITLE
feature/copy-annotations-to-ati-staging-on-submit-review

### DIFF
--- a/features/ati/AtiExportAnnotations/index.tsx
+++ b/features/ati/AtiExportAnnotations/index.tsx
@@ -85,6 +85,7 @@ const AtiExportAnnotations: FC<AtiExportAnnotationstProps> = ({
         return axios.post(
           `/api/hypothesis/${datasetId}/export-annotations`,
           JSON.stringify({
+            isAdminAuthor: false,
             destinationUrl: target.destinationUrl.value,
             annotations: data.annotations,
             destinationHypothesisGroup: target.destinationHypothesisGroup.value,

--- a/pages/api/hypothesis/[id]/export-annotations.ts
+++ b/pages/api/hypothesis/[id]/export-annotations.ts
@@ -11,6 +11,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (session) {
       const {
         destinationUrl: url,
+        isAdminAuthor,
         annotations,
         destinationHypothesisGroup,
         privateAnnotation,
@@ -40,7 +41,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
               //references
             }),
             headers: {
-              Authorization: `Bearer ${hypothesisApiToken}`,
+              Authorization: `Bearer ${
+                isAdminAuthor ? process.env.ADMIN_HYPOTHESIS_API_TOKEN : hypothesisApiToken
+              }`,
               "Content-type": "application/json",
               [REQUEST_DESC_HEADER_NAME]: requestDesc,
             },

--- a/pages/ati/[id]/summary.tsx
+++ b/pages/ati/[id]/summary.tsx
@@ -23,9 +23,17 @@ interface AtiPageProps {
   isLoggedIn: boolean
   serverUrl: string
   atiProjectDetails: IATIProjectDetails | null
+  appUrl: string
+  hypthesisAtiStagingGroupId: string
 }
 
-const AtiPage: FC<AtiPageProps> = ({ isLoggedIn, serverUrl, atiProjectDetails }) => {
+const AtiPage: FC<AtiPageProps> = ({
+  isLoggedIn,
+  serverUrl,
+  atiProjectDetails,
+  appUrl,
+  hypthesisAtiStagingGroupId,
+}) => {
   return (
     <AtiTab
       isLoggedIn={isLoggedIn}
@@ -33,7 +41,12 @@ const AtiPage: FC<AtiPageProps> = ({ isLoggedIn, serverUrl, atiProjectDetails })
       selectedTab={AtiTabConstant.summary.id}
     >
       {atiProjectDetails && (
-        <AtiSummary serverUrl={serverUrl} atiProjectDetails={atiProjectDetails} />
+        <AtiSummary
+          serverUrl={serverUrl}
+          atiProjectDetails={atiProjectDetails}
+          appUrl={appUrl}
+          hypothesisAtiStagingGroupId={hypthesisAtiStagingGroupId}
+        />
       )}
     </AtiTab>
   )
@@ -46,6 +59,8 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     isLoggedIn: false,
     atiProjectDetails: null,
     serverUrl: process.env.DATAVERSE_SERVER_URL as string,
+    appUrl: process.env.NEXTAUTH_URL as string,
+    hypthesisAtiStagingGroupId: process.env.HYPOTHESIS_ATI_STAGING_GROUP_ID as string,
   }
   const session = await getSession(context)
   const datasetId = context?.params?.id


### PR DESCRIPTION
Part of #24. 
When the user submit for review (on the ati summary page), the app download the user's private annotations and copy them to the ati staging group. The copied annotations are public to the ati staging group and author is the admin.
