### PR TITLE
feature/align-6th-step-in-app-guide

### DIFF
--- a/features/components/AppDesc/AppDesc.module.css
+++ b/features/components/AppDesc/AppDesc.module.css
@@ -3,7 +3,7 @@
 }
 
 .leadspaceText {
-  font-size: 2rem;
+  font-size: 1.5rem;
   font-weight: 400;
   letter-spacing: 0;
   line-height: 1.25;

--- a/features/components/AppGuide/AppGuide.module.css
+++ b/features/components/AppGuide/AppGuide.module.css
@@ -6,6 +6,7 @@
 
 .heading {
   padding: 16px;
+  font-size: 1.5rem;
   font-weight: 400;
   border-bottom: 1px solid #dbdbdb;
 }
@@ -26,6 +27,7 @@
 }
 
 .guide h2 {
+  font-size: 1.25rem;
   font-weight: 300;
   margin-bottom: 8px;
 }
@@ -57,9 +59,17 @@
 }
 
 @media (min-width: 42rem) {
+  .heading {
+    font-size: 2.5rem;
+  }
+
   .guide {
     grid-template-columns: 1fr 1fr;
     column-gap: 64px;
+  }
+
+  .guide h2 {
+    font-size: 2rem;
   }
 
   .guide > div:nth-of-type(2) {

--- a/features/components/AppGuide/AppGuide.module.css
+++ b/features/components/AppGuide/AppGuide.module.css
@@ -14,10 +14,14 @@
   display: grid;
   grid-template-columns: 1fr;
   justify-content: space-between;
-  row-gap: 64px;
+}
+
+.guide > div:first-of-type {
+  margin-top: 0;
 }
 
 .guide > div {
+  margin-top: 64px;
   padding: 16px;
 }
 
@@ -39,10 +43,41 @@
   grid-template-columns: 1fr;
 }
 
+.copyAnnotations {
+  position: relative;
+}
+
+.copyAnnotations::before {
+  position: absolute;
+  left: 40%;
+  top: -45px;
+  content: "or";
+  font-size: 1.75rem;
+  font-weight: 300;
+}
+
 @media (min-width: 42rem) {
   .guide {
     grid-template-columns: 1fr 1fr;
     column-gap: 64px;
+  }
+
+  .guide > div:nth-of-type(2) {
+    margin-top: 0;
+  }
+
+  .copyAnnotations {
+    grid-column-end: -1;
+  }
+
+  .copyAnnotations::before {
+    top: -64px;
+  }
+}
+
+@media (min-width: 52rem) {
+  .copyAnnotations::before {
+    top: -75px;
   }
 }
 
@@ -52,5 +87,9 @@
   }
   .guide img {
     width: 80%;
+  }
+
+  .copyAnnotations::before {
+    top: -105px;
   }
 }

--- a/features/components/AppGuide/index.tsx
+++ b/features/components/AppGuide/index.tsx
@@ -70,7 +70,7 @@ const AppGuide: FC<AppGuideProps> = ({ isLoggedIn }) => {
           </h2>
           <img src="./assets/submit.png" alt="" />
         </div>
-        <div>
+        <div className={styles.copyAnnotations}>
           <h2>
             6 b. Copy your <abbr>ATI</abbr> annotations to a copy of your manuscript anywhere on the
             web


### PR DESCRIPTION
- In the list of steps of the app guide, move the last step `copy annotations` to the right so that it sits below `submit for review`.
- Add `or` between `copy annotations` and `submit for review`