### PR TITLE
feature/move-the-app-guide-story

### DIFF
--- a/features/components/AppGuide/AppGuide.stories.tsx
+++ b/features/components/AppGuide/AppGuide.stories.tsx
@@ -4,7 +4,7 @@ import AppGuide, { AppGuideProps } from "."
 
 export default {
   component: AppGuide,
-  title: "Component/App Guide",
+  title: "Getting Started/App Guide",
 } as Meta
 
 const Template: Story<AppGuideProps> = (args) => <AppGuide {...args} />


### PR DESCRIPTION
Move the app guide component story into the `Getting started` section of the storybook website